### PR TITLE
Force int on timestamp parsing

### DIFF
--- a/pyracing/responses/chart_data/irating.py
+++ b/pyracing/responses/chart_data/irating.py
@@ -9,4 +9,4 @@ class IRating:
     # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(timestamp / 1000)
+        return datetime.utcfromtimestamp(int(timestamp) / 1000)

--- a/pyracing/responses/chart_data/license_class.py
+++ b/pyracing/responses/chart_data/license_class.py
@@ -22,4 +22,4 @@ class LicenseClass:
     # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(timestamp / 1000)
+        return datetime.utcfromtimestamp(int(timestamp) / 1000)

--- a/pyracing/responses/chart_data/ttrating.py
+++ b/pyracing/responses/chart_data/ttrating.py
@@ -9,4 +9,4 @@ class TTRating:
     # iRacing has all of their timestamps in ms so we need to divide
     @staticmethod
     def datetime_from_iracing_timestamp(timestamp):
-        return datetime.utcfromtimestamp(timestamp / 1000)
+        return datetime.utcfromtimestamp(int(timestamp) / 1000)


### PR DESCRIPTION
This comes out as a string, so we need to cast it to an int before doing
any division.