### PR TITLE
Use actual urllib decoding

### DIFF
--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -1,7 +1,7 @@
 # _*_ coding: utf_8 _*_
 import time
 import math
-import os
+import urllib.parse
 
 # iRacing rounds down to the 5 minute mark - DO NOT CHANGE
 now_unix_ms = int(math.floor(time.time() / 300) * 300) * 1000
@@ -497,12 +497,5 @@ class CountryCodes:
     ZIMBABWE = 'ZW'
 
 
-# TODO find more of these mappings
-# In a bunch of places the strings we get from iRacing have a bunch of nonsense characters delimited by
-# %, so when we see those cases, we want to make the string actually readable. I assume this is a conversion
-# from a different string format, but I am not sure if there is a way to map them all at once besides this.
-def sanitize_names(string):
-    return string.replace('+', ' ') \
-        .replace('%5B', '(') \
-        .replace('%5D', ')') \
-        .replace('%C3%BC', 'u')
+def parse_iracing_string(string):
+    return urllib.parse.unquote(string).replace('+', ' ')

--- a/pyracing/responses/season.py
+++ b/pyracing/responses/season.py
@@ -1,4 +1,4 @@
-from ..constants import sanitize_names
+from ..constants import parse_iracing_string
 
 
 # I believe this maps what I would call a series, but iRacing calls this a season, so I want to be consistent
@@ -6,7 +6,7 @@ class Season:
     def __init__(self, dict):
         self.season_id = dict['seasonid']
         self.cat_id = dict['catid']
-        self.series_short_name = sanitize_names(dict['seriesshortname'])
+        self.series_short_name = parse_iracing_string((dict['seriesshortname']))
         self.year = self.value_or_none(dict, 'year')
         self.quarter = self.value_or_none(dict, 'quarter')
         self.series_id = self.value_or_none(dict, 'seriesid')


### PR DESCRIPTION
Apparently this is a normal thing and I am just an idiot, so this does
the decoding the way it should be done. iRacing still sends all spaces
as +s, so we do need to strip those out still.