### PR TITLE
Auto set current year and season quarter in event results

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -2,6 +2,7 @@ from . import constants as ct
 from .response_objects import career_stats, iracing_data, historical_data
 from .response_objects import chart_data, session_data, upcoming_events
 
+from datetime import datetime, timedelta
 import logging
 import httpx
 import sys
@@ -297,6 +298,7 @@ class Client:
     async def event_results(
             self,
             cust_id,
+            quarter,
             show_races=1,
             show_quals=None,
             show_tts=None,
@@ -316,8 +318,7 @@ class Client:
             order=ct.Sort.descending,
             data_format='json',
             category=ct.Category.road,
-            year=2020,
-            quarter=3,
+            year=datetime.today().year,
             race_week=None,
             track_id=None,
             car_class=None,

--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -2,6 +2,7 @@
 import time
 import math
 import urllib.parse
+from datetime import datetime
 
 
 # Context sites for the 2 types of endpoints
@@ -570,6 +571,8 @@ class CountryCodes:
 
 
 def parse_encode(string):
+    if not string:
+        return None
     return urllib.parse.unquote(string).replace('+', ' ')
 
 
@@ -577,3 +580,8 @@ def now_five_min_floor():
     """ Takes the current time and rounds down to the nearest five minute mark
     """
     return int(math.floor(time.time() / 300) * 300) * 1000
+
+
+# iRacing has all of their timestamps in ms so we need to divide
+def datetime_from_iracing_timestamp(timestamp):
+    return datetime.utcfromtimestamp(int(timestamp) / 1000)

--- a/pyracing/response_objects/chart_data.py
+++ b/pyracing/response_objects/chart_data.py
@@ -1,6 +1,4 @@
-from ..constants import ChartType, Category, License
-from datetime import datetime
-
+from ..constants import ChartType, Category, License, datetime_from_iracing_timestamp
 
 class ChartData:
     def __init__(self, category, type, list):
@@ -47,8 +45,3 @@ class LicenseClass:
     def get_safety_rating(string):
         relevant_chars = string[1:]
         return relevant_chars[0] + '.' + relevant_chars[1:]
-
-
-# iRacing has all of their timestamps in ms so we need to divide
-def datetime_from_iracing_timestamp(timestamp):
-    return datetime.utcfromtimestamp(int(timestamp) / 1000)


### PR DESCRIPTION
This won't be exact as seasons can sometimes run over by a week or
under, but generally iracing follows this scheme that they do 3 month
seasons starting in January.