### PR TITLE
Use proper python enums in constants

### DIFF
--- a/client_test.py
+++ b/client_test.py
@@ -62,7 +62,7 @@ class ClientTest(unittest.TestCase):
     async def test_get_irating(self):
         client = await get_client()
         await client.authenticate()
-        response = await client.get_irating(constants.Category.road, 499343)
+        response = await client.get_irating(constants.Category.road.value, 499343)
         self.assertIsInstance(response, chart_data.ChartData)
         for irating in response.list:
             self.assertIsInstance(irating, chart_data.IRating)
@@ -71,7 +71,7 @@ class ClientTest(unittest.TestCase):
     async def test_get_ttrating(self):
         client = await get_client()
         await client.authenticate()
-        response = await client.get_ttrating(constants.Category.road, 499343)
+        response = await client.get_ttrating(constants.Category.road.value, 499343)
         self.assertIsInstance(response, chart_data.ChartData)
         for ttrating in response.list:
             self.assertIsInstance(ttrating, chart_data.TTRating)
@@ -80,7 +80,7 @@ class ClientTest(unittest.TestCase):
     async def test_get_license_class(self):
         client = await get_client()
         await client.authenticate()
-        response = await client.get_license_class(constants.Category.road, 499343)
+        response = await client.get_license_class(constants.Category.road.value, 499343)
         self.assertIsInstance(response, chart_data.ChartData)
         for license_class in response.list:
             self.assertIsInstance(license_class, chart_data.LicenseClass)

--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -231,7 +231,7 @@ class Client:
             watched=None,
             recent=None,
             country='null',
-            category=ct.Category.road,
+            category=ct.Category.road.value,
             class_low=None,
             class_high=None,
             irating_low=None,
@@ -314,8 +314,8 @@ class Client:
             show_prowc=1,
             result_num_low=1,
             result_num_high=25,
-            sort=ct.Sort.start_time,
-            order=ct.Sort.descending,
+            sort=ct.Sort.start_time.value,
+            order=ct.Sort.descending.value,
             data_format='json',
             category=ct.Category.road,
             year=datetime.today().year,
@@ -384,11 +384,11 @@ class Client:
         that are used in the /CareerStats charts. Accessing
         get_irating().current will give the most recent irating of a cust_id
         """
-        chart_type = ct.ChartType.irating
+        chart_type = ct.ChartType.irating.value
         response = await self.stats_chart(category, cust_id, chart_type)
         ir_list = [chart_data.IRating(x) for x in response.json()]
 
-        return chart_data.ChartData(category, ct.ChartType.irating, ir_list)
+        return chart_data.ChartData(category, ct.ChartType.irating.value, ir_list)
 
     async def last_races_stats(self, cust_id):
         """ Returns stat summary for the driver's last 10 races as seen
@@ -457,7 +457,7 @@ class Client:
     async def next_event(
             self,
             series_id,
-            event_type=ct.EventType.race,
+            event_type=ct.EventType.race.value,
             date=ct.now_five_min_floor()
     ):
         """ Returns information about the next event (from the requested time)
@@ -501,8 +501,8 @@ class Client:
             start_time_upper,
             result_num_low=1,
             result_num_high=25,
-            sort=ct.Sort.session_name,
-            order=ct.Sort.ascending
+            sort=ct.Sort.session_name.value,
+            order=ct.Sort.ascending.value
     ):
         """ Returns private sessions that the driver
         has participated in.
@@ -587,7 +587,7 @@ class Client:
             self,
             cust_id,
             subsession_id,
-            sim_session_type=ct.SimSessionType.race
+            sim_session_type=ct.SimSessionType.race.value
     ):
         """ Returns data for all laps completed of a single driver.
         sim_sess_id specifies the laps from practice, qual, or race.
@@ -620,8 +620,8 @@ class Client:
             division=None,
             result_num_low=1,
             result_num_high=25,
-            sort=ct.Sort.champ_points,
-            order=ct.Sort.descending
+            sort=ct.Sort.champ_points.value,
+            order=ct.Sort.descending.value
     ):
         """ Returns the championship point standings of a series.
         This is the same data found in /statsseries.jsp.
@@ -667,7 +667,7 @@ class Client:
         """ Utilizes the stats_chart class to return a list of ttrating values
         that are used in the /CareerStats charts.
         """
-        chart_type = ct.ChartType.ttrating
+        chart_type = ct.ChartType.ttrating.value
         response = await self.stats_chart(category, cust_id, chart_type)
         ttrating_list = [chart_data.TTRating(x) for x in response.json()]
 
@@ -678,7 +678,7 @@ class Client:
         that are used in the /CareerStats charts. See the LicenseClass class
         for how to further use this data.
         """
-        chart_type = ct.ChartType.license_class
+        chart_type = ct.ChartType.license_class.value
         response = await self.stats_chart(category, cust_id, chart_type)
         license_class_list = [chart_data.LicenseClass(x) for
                               x in response.json()]

--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -3,6 +3,7 @@ import time
 import math
 import urllib.parse
 from datetime import datetime
+from enum import Enum
 
 
 # Context sites for the 2 types of endpoints
@@ -144,7 +145,7 @@ URL_MY_RACERS = (mSite + '/GetDriverStatus')
 URL_MEM_DIVISION = (mSite + '/GetMembersDivision')
 
 
-class License:
+class License(Enum):
     rookie = 1
     d_class = 2
     c_class = 3
@@ -153,29 +154,8 @@ class License:
     pro_class = 6
     pro_wc_class = 7
 
-    def number_to_string(self, number):
-        if number == self.rookie:
-            return 'R'
-        elif number == self.d_class:
-            return 'D'
-        elif number == self.c_class:
-            return 'C'
-        elif number == self.b_class:
-            return 'B'
-        elif number == self.a_class:
-            return 'A'
-        elif number == self.pro_class:
-            return 'P'
-        elif number == self.pro_wc_class:
-            return 'P-DWC'
-        else:
-            return None
 
-
-# LOCATIONS (AKA Country Code)
-
-
-class Category:
+class Category(Enum):
     """Holds the index for each type of racing discipline
     """
     oval = 1
@@ -183,38 +163,16 @@ class Category:
     dirt_oval = 3
     dirt_road = 4
 
-    def number_to_string(self, number):
-        if number == self.oval:
-            return 'Oval'
-        elif number == self.road:
-            return 'Road'
-        elif number == self.dirt_oval:
-            return 'Dirt Oval'
-        elif number == self.dirt_road:
-            return 'Dirt Road'
-        else:
-            return None
 
-
-class ChartType:
+class ChartType(Enum):
     """Holds the index for the charts available from stats_chart()
     """
     irating = 1
     ttrating = 2
     license_class = 3
 
-    def number_to_string(self, number):
-        if number == self.irating:
-            return 'iRating'
-        elif number == self.ttrating:
-            return 'TTRating'
-        elif number == self.license_class:
-            return 'License Class'
-        else:
-            return None
 
-
-class EventType:
+class EventType(Enum):
     """Holds the index for the session event type
     """
     test = 1
@@ -225,32 +183,14 @@ class EventType:
     official = 6
     unofficial = 7
 
-    def number_to_string(self, number):
-        if number == self.test:
-            return 'Test'
-        elif number == self.practice:
-            return 'Practice'
-        elif number == self.qualify:
-            return 'Qualify'
-        elif number == self.time_trial:
-            return 'Time Trial'
-        elif number == self.race:
-            return 'Race'
-        elif number == self.official:
-            return 'Official'
-        elif number == self.unofficial:
-            return 'Unofficial'
-        else:
-            return None
 
-
-class SimSessionType:
+class SimSessionType(Enum):
     race = 0
     qualify = -1
     practice = -2
 
 
-class IncFlags:
+class IncFlags(Enum):
     clean = 0
     pitted = 2
     off_track = 4
@@ -264,34 +204,8 @@ class IncFlags:
     clock_smash = 1024
     tow = 2048
 
-    def number_to_string(self, number):
-        if number == self.clean:
-            return 'Clean'
-        elif number == self.pitted:
-            return 'Pitted'
-        elif number == self.off_track:
-            return 'Off Track'
-        elif number == self.black_flag:
-            return 'Black Flag'
-        elif number == self.car_reset:
-            return 'Car Reset'
-        elif number == self.contact:
-            return 'Contact'
-        elif number == self.lost_control:
-            return 'Lost Control'
-        elif number == self.discontinuity:
-            return 'Discontinuity'
-        elif number == self.interpolated_crossing:
-            return 'Interpolated Crossing'
-        elif number == self.clock_smash:
-            return 'Clock Smash'
-        elif number == self.tow:
-            return 'Tow'
-        else:
-            return None
 
-
-class Sort:
+class Sort(Enum):
     """Holds the strings used for types of 'sort by'
     """
     irating = 'irating'
@@ -307,7 +221,7 @@ class Sort:
 # TODO Construct dictionary of carIDs
 
 
-class SessionStatus:
+class SessionStatus(Enum):
     registered = 1
     do_not_join = 2
     ok_to_join = 3
@@ -317,7 +231,7 @@ class SessionStatus:
     rejected = 7
 
 
-class CountryCodes:
+class CountryCodes(Enum):
     """Hold the string index of Country Codes that
     iRacing uses for seperating drivers into clubs
     """

--- a/pyracing/response_objects/chart_data.py
+++ b/pyracing/response_objects/chart_data.py
@@ -10,10 +10,10 @@ class ChartData:
         return self.list[-1]
 
     def type_string(self):
-        return ChartType().number_to_string(self.type)
+        return ChartType(self.type).name
 
     def category_string(self):
-        return Category().number_to_string(self.category)
+        return Category(self.category).name
 
 
 class IRating:
@@ -39,7 +39,7 @@ class LicenseClass:
         self.license_level = self.get_safety_rating(str(tuple[1]))
 
     def class_letter(self):
-        return License().number_to_string(self.class_number)
+        return License(self.class_number).name
 
     @staticmethod
     def get_safety_rating(string):


### PR DESCRIPTION
I was mimicking this behaviour through my own classes because I was
unaware that python3 has enums built in. This should make it a bit
easier to use and manage our various enum mappings.