### PR TITLE
Add httpx to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,25 @@
 import setuptools
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-      name='pyracing',
-      version='0.1.0',
-      author='Jacob Anderson & Xander Riga',
-      description='A complete overhaul of ir_webstats; pyracing is an API'
-      'wrapper for simracing service "iRacing" that queries known URL'
-      'endpoints and returns JSON data that is accessible through objects'
-      'instead of dictionaries.',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url='https://github.com/Esterni/pyracing',
-      packages=setuptools.find_packages(),
-      python_requires='>=3.8',
-      classifiers=[
+    name='pyracing',
+    version='0.1.0',
+    author='Jacob Anderson & Xander Riga',
+    description='A complete overhaul of ir_webstats; pyracing is an API'
+    'wrapper for simracing service "iRacing" that queries known URL'
+    'endpoints and returns JSON data that is accessible through objects'
+    'instead of dictionaries.',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url='https://github.com/Esterni/pyracing',
+    packages=setuptools.find_packages(),
+    python_requires='>=3.8',
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        ],
-      zip_safe=False)
+    ],
+    zip_safe=False,
+    install_requires=['httpx>=0.13.3,<0.14'])


### PR DESCRIPTION
This is our only external dependency. The rest are built in python
modules so as long as the python version is correct, I don't see them
being an issue.

This should resolve #41 