### PR TITLE
Improve tests and some minor improvements

### DIFF
--- a/client_test.py
+++ b/client_test.py
@@ -3,12 +3,11 @@ import dotenv
 import os
 from pyracing import client as pyracing
 from pyracing import constants
-from pyracing.response_objects import career_stats
-from pyracing.response_objects import chart_data
-from pyracing.response_objects import iracing_data
+from pyracing.response_objects import career_stats, chart_data, iracing_data, upcoming_events, historical_data
 import unittest
 
 dotenv.load_dotenv()
+client = pyracing.Client(os.getenv('IRACING_USERNAME'), os.getenv('IRACING_PASSWORD'))
 
 
 def async_test(f):
@@ -21,69 +20,73 @@ def async_test(f):
     return wrapper
 
 
-async def get_client():
-    return pyracing.Client(os.getenv('IRACING_USERNAME'), os.getenv('IRACING_PASSWORD'))
-
-
 class ClientTest(unittest.TestCase):
     @async_test
     async def test_career_stats(self):
-        client = await get_client()
-        await client.authenticate()
         response_list = await client.career_stats(499343)
         for career_stat in response_list:
             self.assertIsInstance(career_stat, career_stats.CareerStats)
 
     @async_test
     async def test_yearly_stats(self):
-        client = await get_client()
-        await client.authenticate()
         response_list = await client.yearly_stats(499343)
         for yearly_stat in response_list:
             self.assertIsInstance(yearly_stat, career_stats.YearlyStats)
 
     @async_test
     async def test_last_races_stats(self):
-        client = await get_client()
-        await client.authenticate()
         response_list = await client.last_races_stats(499343)
         for career_stat in response_list:
             self.assertIsInstance(career_stat, career_stats.LastRacesStats)
 
     @async_test
     async def test_current_seasons(self):
-        client = await get_client()
-        await client.authenticate()
         response_list = await client.current_seasons()
         for season in response_list:
             self.assertIsInstance(season, iracing_data.Season)
 
     @async_test
-    async def test_get_irating(self):
-        client = await get_client()
-        await client.authenticate()
-        response = await client.get_irating(constants.Category.road.value, 499343)
+    async def test_irating(self):
+        response = await client.irating(499343, constants.Category.road.value)
         self.assertIsInstance(response, chart_data.ChartData)
         for irating in response.list:
             self.assertIsInstance(irating, chart_data.IRating)
 
     @async_test
-    async def test_get_ttrating(self):
-        client = await get_client()
-        await client.authenticate()
-        response = await client.get_ttrating(constants.Category.road.value, 499343)
+    async def test_ttrating(self):
+        response = await client.ttrating(499343, constants.Category.road.value)
         self.assertIsInstance(response, chart_data.ChartData)
         for ttrating in response.list:
             self.assertIsInstance(ttrating, chart_data.TTRating)
 
     @async_test
-    async def test_get_license_class(self):
-        client = await get_client()
-        await client.authenticate()
-        response = await client.get_license_class(constants.Category.road.value, 499343)
+    async def test_license_class(self):
+        response = await client.license_class(499343, constants.Category.road.value)
         self.assertIsInstance(response, chart_data.ChartData)
         for license_class in response.list:
             self.assertIsInstance(license_class, chart_data.LicenseClass)
+
+    @async_test
+    async def test_active_op_counts(self):
+        response = await client.active_op_counts()
+        for op_count in response:
+            self.assertIsInstance(op_count, upcoming_events.ActiveOPCount)
+
+    @async_test
+    async def test_all_subsessions(self):
+        response = await client.all_subsessions(33618467)
+        for subsession_id in response:
+            self.assertIsInstance(subsession_id, int)
+
+    @async_test
+    async def test_car_class(self):
+        response = await client.car_class()
+        self.assertIsInstance(response, iracing_data.CarClass)
+
+    @async_test
+    async def test_car_class_with_value(self):
+        response = await client.car_class(1)
+        self.assertIsInstance(response, iracing_data.CarClass)
 
 
 if __name__ == '__main__':

--- a/client_test.py
+++ b/client_test.py
@@ -88,6 +88,33 @@ class ClientTest(unittest.TestCase):
         response = await client.car_class(1)
         self.assertIsInstance(response, iracing_data.CarClass)
 
+    @async_test
+    async def test_last_series(self):
+        response = await client.last_series(499343)
+        for last_series in response:
+            self.assertIsInstance(last_series, career_stats.LastSeries)
+
+    @async_test
+    async def test_member_cars_driven(self):
+        response = await client.member_cars_driven(499343)
+        for car_id in response:
+            self.assertIsInstance(car_id, int)
+
+    @async_test
+    async def test_member_subsession_id_from_session(self):
+        response = await client.member_subsession_id_from_session(499343, 134975301)
+        self.assertIsInstance(response, int)
+
+    @async_test
+    async def test_driver_status(self):
+        response = await client.driver_status(499343)
+        self.assertIsInstance(response, iracing_data.DriverStatus)
+
+    @async_test
+    async def test_next_event(self):
+        response = await client.next_event(228)
+        self.assertIsInstance(response, upcoming_events.NextEvent)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -117,9 +117,9 @@ class Client:
         payload = {'subsessionid': subsession_id}
         url = ct.URL_ALL_SUBSESSIONS
         response = await self._build_request(url, payload)
-        return response.json()
+        return [x['subsessionid'] for x in response.json()]
 
-    async def car_class_by_id(self, car_class_id=0):
+    async def car_class(self, car_class_id=0):
         """ Returns the CarClass data for the associated car_class_id
 
         The default "0" is a "master" CarClass containing a list of CarClass

--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -463,7 +463,7 @@ class Client:
         url = ct.URL_NEXT_EVENT
         response = await self._build_request(url, payload)
 
-        return [upcoming_events.NextEvent(x) for x in response.json]
+        return upcoming_events.NextEvent(response.json())
 
     async def next_session_times(self, season_id):
         """ Returns the next 5 sessions with all of their attributes:\n

--- a/pyracing/response_objects/upcoming_events.py
+++ b/pyracing/response_objects/upcoming_events.py
@@ -1,3 +1,4 @@
+from ..helpers import datetime_from_iracing_timestamp
 
 
 class NextEvent:
@@ -5,7 +6,7 @@ class NextEvent:
         self.driver_count = dict['drivercount']
         self.season_id = dict['seasonid']
         self.session_id = dict['sessionid']
-        self.time_start = dict['start_time']
+        self.time_start = datetime_from_iracing_timestamp(dict['start_time'])
 
 
 # Needs to have fix applied to data before


### PR DESCRIPTION
This tests a few more responses, as well as mapping the subsession
response to just be an integer instead of dictionaries with just IDs. It
also renames car class by id to just `car_class` because it being by ID
is implied by the passing in of an ID.