### PR TITLE
Fixes

### DIFF
--- a/pyracing/response_objects/iracing_data.py
+++ b/pyracing/response_objects/iracing_data.py
@@ -47,12 +47,13 @@ class Season:
 
     class Track:
         def __init__(self, data):
+            self.name = parse_encode(data['name'])
             self.name_lower = parse_encode(data['lowername'])
             self.pkg_id = data['pkgid']
             self.priority = data['priority']
             self.race_week = data['raceweek']
             self.time_of_day = data['timeOfDay']
-            self.track_config = data['config']
+            self.config = parse_encode(data['config'])
 
     # The Season endpoint returns more data for a car than other places
     class SeasonCar(Car):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/Esterni/pyracing',
+    project_urls={
+        "Documentation": "https://esterni.github.io/pyracing/"
+            },
     packages=setuptools.find_packages(),
     python_requires='>=3.8',
     classifiers=[


### PR DESCRIPTION
The Track object was missing the "name" attribute.

Changed attribute "track_config" to "config." Before it was accessed through Track.track_config, which would now be Track.config.

Added the documents URL to setup.py for publishing on PyPi