### PR TITLE
Fix next session times

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -468,13 +468,20 @@ class Client:
     async def next_session_times(self, season_id):
         """ Returns the next 5 sessions with all of their attributes:\n
         starttime, registered drivers, session parameters, etc.
+
+        Response contains dict if sessions are scheduled, otherwise an
+        empty list.
         """
         payload = {'season': season_id}
         url = ct.URL_SESSION_TIMES
         response = await self._build_request(url, payload)
 
-        return [upcoming_events.NextSessionTimes(x) for
-                x in response.json()["d"]["r"]]
+        d = response.json()["d"]
+
+        if isinstance(d, dict):
+            return [upcoming_events.NextSessionTimes(x)for x in d["r"]]
+        else:
+            return []
 
     async def personal_bests(self, cust_id, car_id):
         """ Returns the drivers best laptimes for the given car_id, as seen on

--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -586,7 +586,7 @@ class Client:
             'subsessionid': subsession_id,
             'carclassid': car_class_id,
             'simsesnum': sim_session_type
-            }
+        }
         url = ct.URL_LAPS_ALL
         response = await self._build_request(url, payload)
 

--- a/pyracing/response_objects/upcoming_events.py
+++ b/pyracing/response_objects/upcoming_events.py
@@ -148,7 +148,8 @@ class NextSessionTimes:
         self.leave_marbles = data['15']
         self.max_to_display = data['1']
         self.race_week = data['32']
-        self.race_week_cars = data['26']
+        self.race_week_cars = [self.RaceWeekCars(x)
+                               for x in data['26'].items()]
         self.reg_count = data['16']
         self.rubber_practice = data['13']
         self.rubber_qualify = data['24']
@@ -174,3 +175,11 @@ class NextSessionTimes:
         self.wind_speed_value = data['4']
         # Used outside of d dict; Holds refresh time of data
         # self.reloadtime = dict['18']
+
+    class RaceWeekCars:
+        def __init__(self, data):
+            self.car_id = data[0]
+            self.max_percent_fuel_fill = data[1]["maxPctFuelFill"]
+            self.weight_penalty_kg = data[1]["weightPenaltyKG"]
+            self.max_dry_tire_sets = data[1]["max_dry_tire_sets"]
+            self.power_adjust_percent = data[1]["powerAdjustPct"]


### PR DESCRIPTION
This addresses issue #24.
 
Changes are:

- Check added to `next_session_times()` to catch seasons with no upcoming events;
- Implemented `RaceWeekCars` subclass in `NextSessionTimes`;
- Adds list comprehension to `NextSessionTimes.race_week_cars` to generate new objects.