### PR TITLE
Update logging with current Python best practices.

### DIFF
--- a/client_test.py
+++ b/client_test.py
@@ -1,6 +1,8 @@
 import asyncio
 import dotenv
+import logging
 import os
+import sys
 from pyracing import client as pyracing
 from pyracing import constants
 from pyracing.response_objects import career_stats, chart_data, iracing_data, \
@@ -11,7 +13,14 @@ dotenv.load_dotenv()
 client = pyracing.Client(
     os.getenv('IRACING_USERNAME'),
     os.getenv('IRACING_PASSWORD')
-    )
+)
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="%(asctime)s;%(levelname)s;%(message)s"
+)
 
 
 def async_test(f):

--- a/pyracing/__init__.py
+++ b/pyracing/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger(__name__)

--- a/pyracing/helpers.py
+++ b/pyracing/helpers.py
@@ -1,6 +1,4 @@
-import logging
 import math
-import sys
 import urllib.parse
 from time import time
 from datetime import datetime
@@ -12,16 +10,6 @@ def datetime_from_iracing_timestamp(timestamp):
         return datetime.utcfromtimestamp(int(timestamp) / 1000)
     except Exception:
         return None
-
-
-def default_logger():
-    logging.basicConfig(
-        stream=sys.stdout,
-        level=logging.INFO,
-        datefmt="%Y-%m-%d %H:%M:%S",
-        format="%(asctime)s;%(levelname)s;%(message)s"
-    )
-    return logging.getLogger()
 
 
 def now_five_min_floor():


### PR DESCRIPTION
Changes include:

* Using a named logger for pyracing, instead of the root logger
* Placing the pyracing logger in __init__.py
* Removing the basic logging configuration that caused logs to be
  printed to stdout in a format that the user of pyracing had no choice
  in.