### PR TITLE
python-dotenv==0.14.0 required for client_test.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 httpx==0.13.3
+python-dotenv==0.14.0


### PR DESCRIPTION
`python-dotenv==0.14.0` required for client_test.py, added to requirements.txt