### PR TITLE
Fixed issue #74 (string replace is no longer required)

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -257,7 +257,7 @@ class Client:
         the main /DriverLookup page on iRacing.
         """
         payload = {
-            'search': str(search).replace(' ', '+'),
+            'search': search,
             'friend': friend,
             'watched': watched,
             'recent': recent,


### PR DESCRIPTION
Replacing spaces with '+' is no longer required for the search parameter within the driver_stats method.