### PR TITLE
Add League Seasons 

### DIFF
--- a/client_test.py
+++ b/client_test.py
@@ -210,6 +210,12 @@ class ClientTest(unittest.TestCase):
         response = await client.league_standings(724, 61454)
         self.assertIsInstance(response, league_data.SeasonStandings)
 
+    @async_test
+    async def test_league_season(self):
+        response = await client.league_seasons(724)
+        for season in response:
+            self.assertIsInstance(season, league_data.LeagueSeason)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -837,3 +837,15 @@ class Client:
             return []
 
         return league_data.SeasonStandings(response.json())
+
+    async def league_seasons(self, league_id):
+        """Get the season for a league"""
+        payload = {'leagueID': league_id}
+
+        url = ct.URL_LEAGUE_SEASONS
+        response = await self._build_request(url, payload)
+
+        if not response.json() or not response.json()['d']:
+            return []
+
+        return [league_data.LeagueSeason(x) for x in response.json()['d']['r']]

--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -98,8 +98,9 @@ URL_ALL_SUBSESSIONS = (mSite + '/GetAllSubsessions')
 #                    '&subject=Email%20Subject'
 #                    '&text=Test%20for%20coding%20purposes'
 #                    '&leagueID=1056')
-# URL_LEAGUE_SEASONS = (mSite + '/GetLeagueSeasons'
-#                       'leagueID=1056')
+
+# Only parameter is a leagueID
+URL_LEAGUE_SEASONS = (mSite + '/GetLeagueSeasons')
 # URL_LEAGUE_CALENDAR_SEASON = (mSite + '/GetLeagueCalendarBySeason'
 #                               'leagueID=1056'
 #                               '&leagueSeasonID=46493')

--- a/pyracing/response_objects/league_data.py
+++ b/pyracing/response_objects/league_data.py
@@ -48,3 +48,14 @@ class SeasonDriver:
         self.negative_adjustments = data.get('negative_adjustments')
         self.rn = data.get('rn')
         self.facetype = data.get('facetype')
+
+
+class LeagueSeason:
+    def __init__(self, data):
+        self.season_id = data['1']
+        self.league_points_system_description = parse_encode(data['13'])
+        self.league_points_system_name = parse_encode(data['2'])
+        self.league_points_system_id = data['5']
+        self.active = data['6']
+        self.league_season_name = data['8']
+        self.league_id = data['10']


### PR DESCRIPTION
This PR depends on #80 so that will need to be merged first. This builds the basic league seasons endpoint so we can get seasons for a given league and then query the standings from there.