### PR TITLE
Add parse encode to league season name

### DIFF
--- a/pyracing/response_objects/league_data.py
+++ b/pyracing/response_objects/league_data.py
@@ -57,5 +57,5 @@ class LeagueSeason:
         self.league_points_system_name = parse_encode(data['2'])
         self.league_points_system_id = data['5']
         self.active = data['6']
-        self.league_season_name = data['8']
+        self.league_season_name = parse_encode(data['8'])
         self.league_id = data['10']


### PR DESCRIPTION
This will have `+` in all the spaces, as well as other weird encoding
things that iRacing uses, so we want them removed.