### PR TITLE
Check for iRacing being in maintenance mode when authenticating

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -84,6 +84,12 @@ class Client:
                 'correct, check that a captcha is not required by manually '
                 'visiting members.iracing.com')
             raise AuthenticationError('Login Failed', auth_response)
+        elif str(auth_response.url) == ct.URL_MAINTENANCE:
+            logger.warning(
+                'The login POST request was redirected to the iRacing '
+                'maintenance page. Try again once iRacing has come '
+                'back up from maintenance.')
+            raise AuthenticationError('Login Failed', auth_response)
         else:
             logger.info('Login successful')
 

--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -11,6 +11,7 @@ URL_LOGIN = 'https://members.iracing.com/membersite/login.jsp'
 URL_LOGIN2 = 'https://members.iracing.com/membersite/Login'
 URL_LOGOUT = 'https://members.iracing.com/membersite/LogOut'
 URL_HOME = 'https://members.iracing.com/membersite/member/Home.do'
+URL_MAINTENANCE = 'https://members.iracing.com/maintenance/index.html'
 
 # THE BIG ONES
 URL_DRIVER_STATS = (mStats + '/GetDriverStats')


### PR DESCRIPTION
Disclosure: I work in the Operations group at iRacing.

This PR is intended to prevent users of pyracing from firing off large numbers of requests when iRacing is in maintenance mode.

There are several users utilizing this repo, which is great! However, when we go into maintenance mode, their Discord bots and other apps which run on a schedule will fire off thousands of requests because the current login logic does not account for the maintenance page (we probably should be returning 503 instead of 200, honestly) being returned in the 302 response that is received. As a result, the maintenance page is getting hundreds of thousands of requests and ultimately begin triggering rate limit responses. The servers handle this fine, but it messes up our pretty metrics graphs internally.

