### PR TITLE
Do not send password field as plain text

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -1,7 +1,10 @@
 from pyracing import constants as ct
 
 from pyracing import logger
-from pyracing.helpers import now_five_min_floor
+from pyracing.helpers import (
+    encode_password,
+    now_five_min_floor
+)
 from pyracing.response_objects import (
     career_stats,
     chart_data,
@@ -39,7 +42,7 @@ class Client:
         is to store then in your OS environment and call with os.getenv().
         """
         self.username = username
-        self.password = password
+        self.password = encode_password(username,password)
         self.session = httpx.AsyncClient()
 
     def _rename_numerical_keys(self, response_item, mapping):

--- a/pyracing/helpers.py
+++ b/pyracing/helpers.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import math
 import urllib.parse
 from time import time
@@ -10,6 +12,18 @@ def datetime_from_iracing_timestamp(timestamp):
         return datetime.utcfromtimestamp(int(timestamp) / 1000)
     except Exception:
         return None
+
+
+def encode_password(username, password):
+    """ Encodes the username/password combination as a Base64 string for
+    submission in the password field on iRacing login forms. This is not what
+    iRacing stores as the hashed password. It is merely to prevent the plain
+    text version of a user's password from being transmitted to iRacing.
+    """
+    s256Hash = hashlib.sha256((password + username.lower()).encode('utf-8')).digest()
+    base64Hash = base64.b64encode(s256Hash).decode('utf-8')
+
+    return base64Hash
 
 
 def now_five_min_floor():


### PR DESCRIPTION
Disclosure: I work in the Operations group at iRacing.

With the Season 3 release, the login endpoints for iRacing will begin expecting the password as a Base64 encoded string using the following steps.

1. Convert the username (email) to lowercase
2. Concatenate the output from step 1 to the end of the password
3. Create a SHA256 hash of the output from step 2
4. Encode the output from step 3 in Base64
5. Submit the output from step 4 in the `password` field of the login form

This PR adds a helper function, `encode_password` that performs these steps and changes the password assignment in the `Client` class to use the result returned by this function.

These changes are not compatible with the login forms as they exist in the Season 2 release. As such, this should not be merged until the week of June 6th which is the planned release week for Season 3 when the login forms will begin expecting this new submission format.

I will respond here to any feedback or questions. Additional detail can also be found in the iRacing Forums at:
https://forums.iracing.com/discussion/22109/login-form-changes
