### PR TITLE
Added new endpoint and other small items.

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -790,7 +790,10 @@ class Client:
         url = ct.URL_LAPS_ALL
         response = await self._build_request(url, payload)
 
-        return session_data.RaceLapsAll(response.json())
+        if response.json()['details'] and response.json()['startgrid'] and response.json()['lapdata']:
+            return session_data.RaceLapsAll(response.json())
+        else:
+            return None
 
     async def race_laps_driver(
             self,

--- a/pyracing/constants.py
+++ b/pyracing/constants.py
@@ -24,6 +24,7 @@ URL_SERIES_RACERESULTS = (mStats + '/GetSeriesRaceResults')
 URL_LASTRACE_STATS = (mStats + '/GetLastRacesStats')
 URL_LAST_SERIES = (mStats + '/GetLastSeries')
 URL_RESULTS = (mStats + '/GetResults')
+URL_SEARCH_RESULTS = (mStats + '/SearchSeriesResults')
 URL_WORLD_RECORDS = (mStats + '/GetWorldRecords')
 
 # UPCOMING SESSIONS

--- a/pyracing/response_objects/historical_data.py
+++ b/pyracing/response_objects/historical_data.py
@@ -54,6 +54,52 @@ class EventResults:
         # self.rowcount = dict['rowcount']
 
 
+class SearchResults:
+    def __init__(self, data):
+        self.car_class_id = data['carclassid']
+        self.car_id = data['carid']
+        self.car_name = parse_encode(data['car_name'])
+        self.category_name = parse_encode(data['category'])
+        self.category_id = data['catid']
+        self.cust_id = data['custid']
+        self.date_start = parse_encode(data['start_date'])
+        self.display_name = parse_encode(data['displayname'])
+        self.event_type = data['evttype']
+        self.event_type_name = parse_encode(data['evttypename'])
+        self.group_name = parse_encode(data['groupname'])
+        self.incidents = data['incidents']
+        self.lap_best = parse_encode(data['bestlaptime'])
+        self.lap_best_subsession = parse_encode(data['subsession_bestlaptime'])
+        self.lap_qual_best = parse_encode(data['bestquallaptime'])
+        self.license_group = data['licensegroup']
+        self.official_session = data['officialsession']
+        self.points_champ = data['champpoints']
+        self.points_club = data['clubpoints']
+        self.points_drop_race = data['dropracepoints']
+        self.pos_finish = data['finishing_position']
+        self.pos_finish_class = data['class_finishing_position']
+        self.pos_start = data['starting_position']
+        self.pos_start_class = data['class_starting_position']
+        self.race_week = data['race_week_num']
+        self.season_id = data['seasonid']
+        self.season_quarter = data['seasonid']
+        self.season_year = data['season_year']
+        self.series_id = data['seriesid']
+        self.series_name = parse_encode(data['series_name'])
+        self.series_name_short = parse_encode(data['series_shortname'])
+        self.session_id = data['sessionid']
+        self.strength_of_field = data['strengthoffield']
+        self.subsession_id = data['subsessionid']
+        self.time_finished = data['finishedat']
+        self.time_start = parse_encode(data['start_time'])
+        self.time_start_raw = data['raw_start_time']
+        self.track_id = data['trackid']
+        self.track_name = parse_encode(data['track_name'])
+        self.track_config_name = parse_encode(data['config_name'])
+        self.winner_display_name = parse_encode(data['winnerdisplayname'])
+        self.winners_group_id = data['winnersgroupid']
+
+
 class SeasonStandings:
     def __init__(self, data):
         self.club_id = data['clubid']

--- a/pyracing/response_objects/session_data.py
+++ b/pyracing/response_objects/session_data.py
@@ -179,8 +179,7 @@ class RaceLapsAll:
             self.laps_for_solo_avg = data['nLapsForSoloAvg']
             self.official = data['officialSession']
             self.private_session_id = data['privateSessionID']
-            self.private_session_name = parse_encode(
-                                        data['privateSessionName'])
+            self.private_session_name = parse_encode(data['privateSessionName'])
             self.race_panel_img = parse_encode(data['race_panel_img'])
             self.race_week = data['raceWeek']
             self.season_id = data['seasonID']


### PR DESCRIPTION
- Added search_results() and corresponding SearchResults response object to use the newer results endpoint. iRacing has requested this endpoint be used over the one used by event_results().
- Changed allow_redirects to follow_redirects for compatibility with newer versions of httpx.
- Added check for 'rows' in personal_bests() response.
- Added check for response in subsession_data().