### PR TITLE
Added a few things

### DIFF
--- a/pyracing/client.py
+++ b/pyracing/client.py
@@ -33,7 +33,7 @@ import time
 
 
 class Client:
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str, timeout=10.0):
         """ This class is used to interact with all iRacing endpoints that
         have been discovered so far. After creating an instance of Client
         it is required to call authenticate(), due to async limitations.
@@ -43,6 +43,7 @@ class Client:
         """
         self.username = username
         self.password = encode_password(username,password)
+        self.timeout = timeout
         self.session = httpx.AsyncClient()
 
     def _rename_numerical_keys(self, response_item, mapping):
@@ -109,7 +110,7 @@ class Client:
             url,
             params=params,
             allow_redirects=False,
-            timeout=10.0
+            timeout=self.timeout
         )
         logger.info(f'Request sent for URL: {response.url}')
         logger.info(f'Status code of response: {response.status_code}')

--- a/pyracing/response_objects/session_data.py
+++ b/pyracing/response_objects/session_data.py
@@ -76,6 +76,7 @@ class SubSessionData:
             self.car_color_2 = data['car_color2']
             self.car_color_3 = data['car_color3']
             self.car_id = data['carid']
+            self.car_name = str(data['car_name']).replace('+', '')
             self.car_num = data['carnum']
             self.car_num_font = data['carnumberfont']
             self.car_num_slant = data['carnumberslant']

--- a/pyracing/response_objects/session_data.py
+++ b/pyracing/response_objects/session_data.py
@@ -76,7 +76,7 @@ class SubSessionData:
             self.car_color_2 = data['car_color2']
             self.car_color_3 = data['car_color3']
             self.car_id = data['carid']
-            self.car_name = str(data['car_name']).replace('+', '')
+            self.car_name = parse_encode(data['car_name'])
             self.car_num = data['carnum']
             self.car_num_font = data['carnumberfont']
             self.car_num_slant = data['carnumberslant']


### PR DESCRIPTION
- Added timeout parameter to the Client, so it can be defined when instance is created instead of being hardcoded to 10 seconds.
This was necessary because, especially when using `driver_stats()` as this may take more than 10 seconds.

**Example**
To set it to 30 seconds
```ir = Client(IRACING_USERNAME, IRACING_PASSWORD, 30.0)``` 


- Added car_name to the Subsession Driver object, not sure why it wasn't there.
I tried going the long way around it first, by getting the car class, iterate and find a match from the car_id, and this works for older seasons, but not the newer ones.

However it car_name seems to be present in GetSubsessionResults for old and new sessions.